### PR TITLE
Working on rust implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "0.12.0"
 source = "git+https://github.com/Covertness/coap-rs#afa7d108f8cd6b219ceaf1f0fced36b6e8551ddf"
 dependencies = [
  "bytes",
- "coap-lite",
+ "coap-lite 0.9.1",
  "futures",
  "log",
  "lru_time_cache",
@@ -70,6 +70,12 @@ checksum = "3b4859ead43cef7e14593c5238cb3dd8800f41ade206bdf08c44c51f2d943fd3"
 dependencies = [
  "lru_time_cache",
 ]
+
+[[package]]
+name = "coap-lite"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca11cbc756cf12eb24824285dbe36d97e4cfea404aaa1240477f3ae091f779"
 
 [[package]]
 name = "fluent"
@@ -319,6 +325,12 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "ntapi"
@@ -728,6 +740,10 @@ dependencies = [
 [[package]]
 name = "vap-client-register"
 version = "0.1.0"
+dependencies = [
+ "coap-lite 0.11.3",
+ "no-std-net",
+]
 
 [[package]]
 name = "vap-common"
@@ -747,7 +763,7 @@ name = "vap-skill-framework"
 version = "0.1.0"
 dependencies = [
  "coap",
- "coap-lite",
+ "coap-lite 0.9.1",
  "fluent",
  "fluent-langneg",
  "futures",
@@ -767,7 +783,7 @@ name = "vap-skill-register"
 version = "0.1.0"
 dependencies = [
  "coap",
- "coap-lite",
+ "coap-lite 0.9.1",
  "futures",
  "rmp",
  "rmp-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca11cbc756cf12eb24824285dbe36d97e4cfea404aaa1240477f3ae091f779"
 
 [[package]]
+name = "embedded-nal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a943fad5ed3d3f8a00f1e80f6bba371f1e7f0df28ec38477535eb318dc19cc"
+dependencies = [
+ "nb",
+ "no-std-net",
+]
+
+[[package]]
 name = "fluent"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +335,12 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "no-std-net"
@@ -742,7 +758,9 @@ name = "vap-client-register"
 version = "0.1.0"
 dependencies = [
  "coap-lite 0.11.3",
+ "embedded-nal",
  "no-std-net",
+ "vap-common",
 ]
 
 [[package]]

--- a/README.MD
+++ b/README.MD
@@ -10,6 +10,7 @@ Here you will find:
 
 * **Implementations:** Inside `vap-client-register`, `vap-common`, `vap-common-client`, `vap-common-skill`, `vap-skill-register`, `vap-skill-framework` and `vap-python-skill` folders are the reference implementations. The skill client code is in Python as well as Rust, for better accessibility while everything else is in Rust for running it even on devices with limited capabilities. Note: The skill client code in Python is meant as a simple example implementing directly VAP, do note that the implementation there does not cover every single error handling of the protocol.
 
+* **API**: Inside the `api` folder are OpenAPI specifications for the client and skill registry.
 ## Implementations
 
 

--- a/api/client_registry.json
+++ b/api/client_registry.json
@@ -1,0 +1,347 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "VAP Client Registry API",
+        "version": "0.0.1"
+    },
+    "paths": {
+        "/Server/vap/clientRegistry/connect": {
+            "post": {
+                "summary": "Initiate a connection to the server",
+                "description": "Register a client with the server and establish a connection.",
+                "operationId": "connectClient",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "type": "string",
+                                        "description": "Unique identifier for the client, like org.company.product"
+                                    },
+                                    "vapVersion": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "id",
+                                    "vapVersion"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Client successfully registered",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "locales": {
+                                            "type": "string",
+                                            "description": "Locale information"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "format": "int32"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/Server/vap/clientRegistry/sessionStart": {
+            "post": {
+                "summary": "Start a session",
+                "description": "Signals that a client wants to start a session.",
+                "operationId": "startSession",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "capabilities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "exactTimeStamp": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Session successfully started",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/Server/vap/clientRegistry/sessionData": {
+            "post": {
+                "summary": "Send session data",
+                "description": "Sends data during a session.",
+                "operationId": "sendSessionData",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "capabilities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "lastFragment": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Session data successfully received",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "capabilities": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "endSession": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "231": {
+                        "description": "Continue sending session data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/Client/vap/notification": {
+            "post": {
+                "summary": "Receive notification",
+                "description": "Receive a notification from the registry.",
+                "operationId": "receiveNotification",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "capabilities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "from": {
+                                                    "type": "string",
+                                                    "description": "Skill name or the system itself."
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Notification successfully received",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/Server/vap/clientRegistry/clientClose": {
+            "post": {
+                "summary": "Close client connection",
+                "description": "Closes the connection for a client.",
+                "operationId": "closeClientConnection",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "clientId": {
+                                        "type": "string",
+                                        "description": "The unique identifier for the client."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Client connection successfully closed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "format": "int32"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        },
+                                        "object": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "integer",
+                                            "format": "int32"
+                                        },
+                                        "type": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/vap-client-register/Cargo.toml
+++ b/vap-client-register/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vap-client-register"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,3 +9,5 @@ edition = "2018"
 #toad_msg = { version = "0.0.1", default-features = false }
 coap-lite = { version = "0.11.3", default-features = false }
 no-std-net = "0.6.0"
+embedded-nal = "0.8.0"
+vap-common = { path = "../vap-common" }

--- a/vap-client-register/Cargo.toml
+++ b/vap-client-register/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+#toad_msg = { version = "0.0.1", default-features = false }
+coap-lite = { version = "0.11.3", default-features = false }
+no-std-net = "0.6.0"

--- a/vap-client-register/src/etc.rs
+++ b/vap-client-register/src/etc.rs
@@ -1,0 +1,108 @@
+// trait CoapTransport {
+//     fn send(&self, message: &CoapMessage) -> Result<(), std::io::Error>;
+//     fn receive(&self) -> Result<CoapMessage, std::io::Error>;
+// }
+
+// impl CoapTransport for UdpClientStack {
+//     fn send(&self, message: &CoapMessage) -> Result<(), std::io::Error> {
+//         todo!()
+//     }
+
+//     fn receive(&self) -> Result<CoapMessage, std::io::Error> {
+//         todo!()
+//     }
+//     // Implement the methods for UDP
+
+// }
+
+// impl CoapTransport for TcpClientStack {
+//     fn send(&self, message: &CoapMessage) -> Result<(), std::io::Error> {
+//         todo!()
+//     }
+
+//     fn receive(&self) -> Result<CoapMessage, std::io::Error> {
+//         todo!()
+//     }
+//     // Implement the methods for TCP
+// }
+// struct InitializedNetworkStack<ToSocketAddrs> {
+//     bind_addr: ToSocketAddrs,
+//     peer_addr: ToSocketAddrs,
+// }
+
+// impl<ToSocketAddrs> UdpClientStack for InitializedNetworkStack<ToSocketAddrs> {
+//     fn new(bind_addr: ToSocketAddrs, peer_addr: ToSocketAddrs) -> Self {
+//         Self {
+//             bind_addr,
+//             peer_addr,
+//         }
+//     }
+
+//     type UdpSocket;
+
+//     type Error;
+
+//     fn socket(&mut self) -> Result<Self::UdpSocket, Self::Error> {
+//         todo!()
+//     }
+
+//     fn connect(
+// 		    &mut self,
+// 		    socket: &mut Self::UdpSocket,
+// 		    remote: no_std_net::SocketAddr,
+// 	    ) -> Result<(), Self::Error> {
+//         todo!()
+//     }
+
+//     fn send(&mut self, socket: &mut Self::UdpSocket, buffer: &[u8]) -> embedded_nal::nb::Result<(), Self::Error> {
+//         todo!()
+//     }
+
+//     fn receive(
+// 		    &mut self,
+// 		    socket: &mut Self::UdpSocket,
+// 		    buffer: &mut [u8],
+// 	    ) -> embedded_nal::nb::Result<(usize, no_std_net::SocketAddr), Self::Error> {
+//         todo!()
+//     }
+
+//     fn close(&mut self, socket: Self::UdpSocket) -> Result<(), Self::Error> {
+//         todo!()
+//     }
+// }
+
+// fn init_udp(bind_addr: ToSocketAddrs, peer_addr: ToSocketAddrs) -> InitializedNetworkStack {
+//     let socket = UdpClientStack::new(bind_addr, peer_addr);
+//     InitializedTransport::Udp(socket)
+// }
+
+// impl<Endpoint> VAPClient<Endpoint> {
+//     pub fn new(endpoint: Endpoint, name: String, id: String, vap_version: String) -> Self {
+//         Self {
+//             endpoint,
+//             name,
+//             id,
+//             vap_version,
+//         }
+//     }
+//     pub fn connect(&self, socket: UdpClientStack) -> Result<Locale, Error> {
+
+//     let mut packet = Packet::new();
+//     packet.header.set_type(MessageType::Confirmable);
+//     packet.header.code = MessageClass::Request(RequestType::Post);
+
+//     packet.payload = format!("name={},id={},vapVersion={}", self.name, self.id, self.vap_version).into();
+//     let mut req = CoapRequest::from_packet(packet, self.endpoint);
+
+//     req.set_path("Server/vap/clientRegistry/connect");
+
+//     socke
+//     send_to(req.message.to_bytes(), self.endpoint).unwrap();
+
+//     let mut res =
+//     println!("Response: {:?}", res);
+//     let payload = res.get_payload().unwrap();
+//     println!("Payload: {:?}", payload);
+//     }
+
+// }

--- a/vap-client-register/src/lib.rs
+++ b/vap-client-register/src/lib.rs
@@ -1,3 +1,75 @@
-fn main() {
-    println!("Hello, world!");
+use coap_lite::{CoapRequest, CoapResponse, MessageClass, MessageType, Packet, RequestType};
+use no_std_net::SocketAddr;
+pub struct VAPClient<Endpoint> {
+    endpoint: Endpoint,
+    name: String,
+    id: String,
+    vap_version: String,
+}
+
+impl<Endpoint> VAPClient<Endpoint> {
+    pub fn new(endpoint: Endpoint, name: String, id: String, vap_version: String) -> Self {
+        Self {
+            endpoint,
+            name,
+            id,
+            vap_version,
+        }
+    }
+    pub fn connect(&self, socket: SocketAddr) -> Result<Locale, Error> {
+     
+    let mut packet = Packet::new();
+    packet.header.set_type(MessageType::Confirmable);
+    packet.header.code = MessageClass::Request(RequestType::Post);
+
+    packet.payload = format!("name={},id={},vapVersion={}", self.name, self.id, self.vap_version).into();
+    let mut req = CoapRequest::from_packet(packet, self.endpoint);
+    
+    req.set_path("Server/vap/clientRegistry/connect");
+    
+    socket.send_to(req.message.to_bytes(), self.endpoint).unwrap();
+
+    
+    let mut res = 
+    println!("Response: {:?}", res);
+    let payload = res.get_payload().unwrap();
+    println!("Payload: {:?}", payload);
+    }
+
+}
+
+// *POST* **Server/vap/clientRegistry/connect** (Confirmable: Mandatory, Client -> Registry)
+// * name:
+// * id: String -> (like org.company.product)
+// * vapVersion:
+
+// **Answer**
+// * One of:
+//     * OK! (Code: 201 Created)
+//         * locales: Locale
+//     * Errors:
+//         * 400 Bad Request: Id already exists? (should Ids be unique?)
+//         * 400 Bad Request: vapVersion incompatible
+//         * 401 Unauthorized: connection denied by policy or by the user (maybe the user didn't accept the client or it is blocked)
+//             * code = 401
+//             * type = "connectionDenied"
+
+// The server will answer a UniqueAuthenticationToken only if this is the first time the client is connecting and we don't have any record of it.
+pub fn connect(endpoint: Endpoint, name: String, id: String, vap_version: String) -> Result<Locale, Error> {
+    let mut packet = Packet::new();
+    packet.header.set_type(MessageType::Confirmable);
+    packet.header.code = MessageClass::Request(RequestType::Post);
+
+    packet.payload = format!("name={},id={},vapVersion={}", name, id, vap_version).into();
+    let mut req = CoapRequest::from_packet(packet, None)
+    from_packet(packet, )
+    req.set_method(RequestType::Post);
+    req.set_path("Server/vap/clientRegistry/connect");
+
+    req.set_payload("vapVersion".as_bytes().to_vec());
+    let mut res = req.send("coap://localhost:5683").unwrap();
+    println!("Response: {:?}", res);
+    let payload = res.get_payload().unwrap();
+    println!("Payload: {:?}", payload);
+    Ok(Locale {})
 }

--- a/vap-common/src/capability.rs
+++ b/vap-common/src/capability.rs
@@ -1,0 +1,76 @@
+pub enum Capability {
+    Sound,
+    Text, //should this be a separate capability?
+    Image,
+    WakeWordSync,
+    WakeWordAudio,
+    Log,
+    DynamicNLU,
+}
+
+pub struct CapabilityCode(u8);
+
+impl From<&str> for Capability {
+    fn from(capability: &str) -> Self {
+        match capability.to_lowercase().as_str() {
+            "sound" => Self::Sound,
+            "text" => Self::Text,
+            "image" => Self::Image,
+            "wakewordsync" => Self::WakeWordSync,
+            "wakewordaudio" => Self::WakeWordAudio,
+            "log" => Self::Log,
+            "dynamicnlu" => Self::DynamicNLU,
+            _ => panic!("Unknown capability: {}", capability),
+        }
+    }
+}
+
+impl From<CapabilityCode> for Capability {
+    fn from(capability: CapabilityCode) -> Self {
+        match capability.0 {
+            0 => Self::Sound,
+            1 => Self::Text,
+            2 => Self::Image,
+            3 => Self::WakeWordSync,
+            4 => Self::WakeWordAudio,
+            5 => Self::Log,
+            6 => Self::DynamicNLU,
+            _ => panic!("Unknown capability: {}", capability.0),
+        }
+    }
+}
+
+impl From<Capability> for CapabilityCode {
+    fn from(capability: Capability) -> Self {
+        match capability {
+            Capability::Sound => Self(0),
+            Capability::Text => Self(1),
+            Capability::Image => Self(2),
+            Capability::WakeWordSync => Self(3),
+            Capability::WakeWordAudio => Self(4),
+            Capability::Log => Self(5),
+            Capability::DynamicNLU => Self(6),
+        }
+    }
+}
+
+impl CapabilityCode {
+    pub fn to_u8(&self) -> u8 {
+        self.0
+    }
+}
+// pub struct Capabilities {
+//     capabilities: &'static [CapabilityCode],
+// }
+
+// impl Default for Capabilities {
+//     fn default() -> Self {
+//         Self { capabilities: &[] }
+//     }
+// }
+
+// impl Capabilities {
+//     pub fn new(capabilities: &[Capabilities]) -> Self {
+//         caps = [capabilities.len()]
+//     }
+// }

--- a/vap-common/src/lib.rs
+++ b/vap-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+pub mod capability;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
I created an OpenAPI.json because it apparently can be used to describe non-html protocols such as CoAP, and in the future it might be beneficial for generation of client or server bindings. 

I used the newtype pattern to format the request the clients have to send, still trying to figure out how to do that for the responses. I added an enum for Capabilities. I'm thinking of adding a build.rs file to the vap-common part of the library to define compile time constants(such as vap version, and perhaps capabilities). 

I'm trying to avoid writing the network stuff that forces the user to use TCP or UDP, but just requires that the NetworkStuff has been initialized by the time the client is making request. 

I'm thinking we should write it in a way that Servers are probably compiled with std, but clients may be resource constrained and thus, should be client-centric code should be written explicitly with `#![no_std]`